### PR TITLE
svm.cpp printing string correctly

### DIFF
--- a/src/svm.cpp
+++ b/src/svm.cpp
@@ -48,7 +48,7 @@ static void print_string_stdout(const char *s)
 	fputs(s,stdout);
 	fflush(stdout);
 	*/
-	Rprintf(s);
+	Rprintf("%s", s);
 }
 static void (*svm_print_string) (const char *) = &print_string_stdout;
 #if 0


### PR DESCRIPTION
Fixes the 'warning: format string is not a string literal (potentially insecure)' that, afaics, got this package thrown off CRAN.